### PR TITLE
33 logger

### DIFF
--- a/src/octopeer-github/content/_ref.ts
+++ b/src/octopeer-github/content/_ref.ts
@@ -1,2 +1,3 @@
 /// <reference path="../../../typings/main.d.ts"/>
 /// <reference path="../main/DatabaseAdaptable/DatabaseAdaptable.ts"/>
+/// <reference path="../main/Logger.ts"/>

--- a/src/octopeer-github/main/DatabaseAdaptable/ConsoleLogDatabaseAdapter.ts
+++ b/src/octopeer-github/main/DatabaseAdaptable/ConsoleLogDatabaseAdapter.ts
@@ -10,7 +10,7 @@ class ConsoleLogDatabaseAdapter implements DatabaseAdaptable {
      * @param eventData The data to log to the console.
      */
     public post(eventData: EventObject) {
-        console.log("[Database] ", eventData);
+        Logger.database(eventData);
     }
 
 }

--- a/src/octopeer-github/main/DatabaseAdaptable/RESTApiDatabaseAdapter.ts
+++ b/src/octopeer-github/main/DatabaseAdaptable/RESTApiDatabaseAdapter.ts
@@ -24,14 +24,16 @@ class RESTApiDatabaseAdapter implements DatabaseAdaptable {
             .done(function(data, status, jqXHR) {
                 self._session = self.getSessionFromUrl(data.url);
                 if (self._debug) {
-                    console.log(`Initialized DatabaseAdapter(${_url}, session=${self._session})`, self);
+                    Logger.debug(`Initialized DatabaseAdapter(${_url}, session=${self._session})`);
+                    Logger.debug(self);
                 }
             })
             .fail(function(jqXHR, status) {
-                console.log(`[WARN] DatabaseAdapter could not connect to ${self.url}.`, jqXHR);
+                Logger.log(`DatabaseAdapter could not connect to ${self.url}.`);
+                Logger.debug(jqXHR);
             });
         if (self._debug) {
-            console.log(`Constructed DatabaseAdapter(${_url})`, self);
+            Logger.debug(`Constructed DatabaseAdapter(${_url})`).debug(self);
         }
     }
 
@@ -64,23 +66,22 @@ class RESTApiDatabaseAdapter implements DatabaseAdaptable {
     public post(eventData: EventObject, success: Callback, failure: Callback): void {
         const self = this;
         if (!this.isInitialized) {
-            console.log("[WARN] The database has not been initialized yet!");
+            Logger.log("The database has not been initialized yet!");
             return;
         }
-        const ajax = $.ajax(`${this.url}api/events/`, self.createPostData(eventData))
+        $.ajax(`${this.url}api/events/`, self.createPostData(eventData))
             .done(function(data, status, jqXHR) {
                 if (self._debug) {
-                    console.log(`Call success, status: ${status}`, jqXHR);
+                    Logger.debug(`Call success, status: ${status}`);
+                    Logger.debug(jqXHR);
                 }
                 success(data, status, jqXHR);
             })
             .fail(function(jqXHR, status) {
-                console.log(`[WARN] Call failed, status: ${status}`, jqXHR);
+                Logger.log(`Database post failed, status: ${status}`);
+                Logger.debug(jqXHR);
                 failure(jqXHR, status);
             });
-        if (self._debug) {
-            console.log("Sent out AJAX request: ", ajax);
-        }
     }
 
     /**

--- a/src/octopeer-github/main/DatabaseAdaptable/RESTApiDatabaseAdapter.ts
+++ b/src/octopeer-github/main/DatabaseAdaptable/RESTApiDatabaseAdapter.ts
@@ -33,7 +33,8 @@ class RESTApiDatabaseAdapter implements DatabaseAdaptable {
                 Logger.debug(jqXHR);
             });
         if (self._debug) {
-            Logger.debug(`Constructed DatabaseAdapter(${_url})`).debug(self);
+            Logger.debug(`Constructed DatabaseAdapter(${_url})`);
+            Logger.debug(self);
         }
     }
 

--- a/src/octopeer-github/main/DatabaseAdaptable/RESTApiDatabaseAdapter.ts
+++ b/src/octopeer-github/main/DatabaseAdaptable/RESTApiDatabaseAdapter.ts
@@ -29,7 +29,7 @@ class RESTApiDatabaseAdapter implements DatabaseAdaptable {
                 }
             })
             .fail(function(jqXHR, status) {
-                Logger.log(`DatabaseAdapter could not connect to ${self.url}.`);
+                Logger.warn(`DatabaseAdapter could not connect to ${self.url}.`);
                 Logger.debug(jqXHR);
             });
         if (self._debug) {
@@ -67,7 +67,7 @@ class RESTApiDatabaseAdapter implements DatabaseAdaptable {
     public post(eventData: EventObject, success: Callback, failure: Callback): void {
         const self = this;
         if (!this.isInitialized) {
-            Logger.log("The database has not been initialized yet!");
+            Logger.warn("The database has not been initialized yet!");
             return;
         }
         $.ajax(`${this.url}api/events/`, self.createPostData(eventData))
@@ -79,7 +79,7 @@ class RESTApiDatabaseAdapter implements DatabaseAdaptable {
                 success(data, status, jqXHR);
             })
             .fail(function(jqXHR, status) {
-                Logger.log(`Database post failed, status: ${status}`);
+                Logger.warn(`Database post failed, status: ${status}`);
                 Logger.debug(jqXHR);
                 failure(jqXHR, status);
             });

--- a/src/octopeer-github/main/Logger.ts
+++ b/src/octopeer-github/main/Logger.ts
@@ -2,28 +2,53 @@
  * Created by Maarten on 17-05-2016.
  */
 
+/**
+ * The Logger class (singleton) is used to log events to the console.
+ * The Logger will not output debug messages if this is not explicitly requested.
+ */
 const Logger = new (class Logger {
 
     private isDebug = false;
 
+    /**
+     * Logs a warning to the console.
+     * @param obj The object to be logged.
+     */
     public warn(obj: any) {
         this.log("WARN ", obj);
     }
 
+    /**
+     * Logs a debug message to the console.
+     * @param obj The object to be logged.
+     */
     public debug(obj: any) {
         if (this.isDebug) {
             this.log("DEBUG", obj);
         }
     }
 
+    /**
+     * Logs a database post to the console. (only used by ConsoleLogDatabaseAdapter)
+     * @param obj The object to be logged.
+     */
     public database(obj: any) {
         this.log("DATA ", obj);
     }
 
+    /**
+     * If debug = true, the Logger will log debug messages.
+     * @state state=true The new debug state.
+     */
     public setDebug(state = true) {
         this.isDebug = state;
     }
 
+    /**
+     * Logs a warning to the console.
+     * @param tag The tag that this log will get.
+     * @param obj The object to be logged.
+     */
     private log(tag: string, obj: any) {
         console.log(`[${tag}] `, obj);
     }

--- a/src/octopeer-github/main/Logger.ts
+++ b/src/octopeer-github/main/Logger.ts
@@ -6,25 +6,25 @@ const Logger = new (class Logger {
 
     private isDebug = false;
 
-    public log(obj: any) {
-        this._log("WARN ", obj);
+    public warn(obj: any) {
+        this.log("WARN ", obj);
     }
 
     public debug(obj: any) {
         if (this.isDebug) {
-            this._log("DEBUG", obj);
+            this.log("DEBUG", obj);
         }
     }
 
     public database(obj: any) {
-        this._log("DATA ", obj);
+        this.log("DATA ", obj);
     }
 
     public setDebug(state = true) {
         this.isDebug = state;
     }
 
-    private _log(tag: string, obj: any) {
+    private log(tag: string, obj: any) {
         console.log(`[${tag}] `, obj);
     }
 

--- a/src/octopeer-github/main/Logger.ts
+++ b/src/octopeer-github/main/Logger.ts
@@ -1,0 +1,32 @@
+/**
+ * Created by Maarten on 17-05-2016.
+ */
+
+const Logger = new (class Logger {
+
+    private isDebug = false;
+
+    public log(obj: any) {
+        this._log("WARN ", obj);
+    }
+
+    public debug(obj: any) {
+        if (this.isDebug) {
+            this._log("DEBUG", obj);
+        }
+    }
+
+    public database(obj: any) {
+        this._log("DATA ", obj);
+    }
+
+    public setDebug(state = true) {
+        this.isDebug = state;
+    }
+
+    private _log(tag: string, obj: any) {
+        console.log(`[${tag}] `, obj);
+    }
+
+})();
+Logger.debug(""); // Suppress unused variable `Logger`

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -47,10 +47,10 @@ class MainController {
                 return; // Only continue if message is sent from a content script
             }
             self.database.post(JSON.parse(message), function() {
-                console.log("[Database] Successfully logged to database: ", message);
+                Logger.debug(`Successfully logged to database: ${message}`);
             }, function() {
-                console.log("[WARN] Log to database of following object failed: ", message);
-                console.log("[WARN] Original sender: ", sender);
+                Logger.log("Log to database of following object failed:").log(message);
+                Logger.log(`Original sender: ${sender}`);
             });
             sendResponse({});
         });
@@ -74,12 +74,12 @@ class MainController {
         const urlFormat = /https?:\/\/.*github\.com\/(.+)\/(.+)\/pull\/([^\/]+)\/?.*/;
         if (urlFormat.test(url)) {
             let urlInfo = urlFormat.exec(url);
-            console.log(`[Tab] Owner: ${urlInfo[1]}, Repo: ${urlInfo[2]}, PR-number: ${urlInfo[3]}`);
+            Logger.debug(`[Tab] Owner: ${urlInfo[1]}, Repo: ${urlInfo[2]}, PR-number: ${urlInfo[3]}`);
             chrome.tabs.sendMessage(tab.id, {
                 hookToDom: true,
             }, function(result) {
                 let str = result || `should be refreshed because content script is not loaded (${tab.url})`;
-                console.log(`[Tab] ${str}`);
+                Logger.debug(`[Tab] ${str}`);
             });
         }
     }

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -49,9 +49,9 @@ class MainController {
             self.database.post(JSON.parse(message), function() {
                 Logger.debug(`Successfully logged to database: ${message}`);
             }, function() {
-                Logger.log("Log to database of following object failed:");
-                Logger.log(message);
-                Logger.log(`Original sender: ${sender}`);
+                Logger.warn("Log to database of following object failed:");
+                Logger.warn(message);
+                Logger.warn(`Original sender: ${sender}`);
             });
             sendResponse({});
         });

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -49,7 +49,8 @@ class MainController {
             self.database.post(JSON.parse(message), function() {
                 Logger.debug(`Successfully logged to database: ${message}`);
             }, function() {
-                Logger.log("Log to database of following object failed:").log(message);
+                Logger.log("Log to database of following object failed:");
+                Logger.log(message);
                 Logger.log(`Original sender: ${sender}`);
             });
             sendResponse({});

--- a/src/octopeer-github/test/DatabaseAdaptable/RESTApiDatabaseAdapterTest.ts
+++ b/src/octopeer-github/test/DatabaseAdaptable/RESTApiDatabaseAdapterTest.ts
@@ -58,7 +58,7 @@ describe("A RESTApiDatabaseAdapter", function() {
     });
 
     it("cannot post to the API when not initialized", function() {
-        spyOn(Logger, "_log"); // suppress Logger logs of all levels
+        spyOn(Logger, "log"); // suppress Logger logs of all levels
         delete adapter;
         adapter = new RESTApiDatabaseAdapter("http://localhost:8000", 1, 1);
 

--- a/src/octopeer-github/test/DatabaseAdaptable/RESTApiDatabaseAdapterTest.ts
+++ b/src/octopeer-github/test/DatabaseAdaptable/RESTApiDatabaseAdapterTest.ts
@@ -15,6 +15,8 @@ describe("A RESTApiDatabaseAdapter", function() {
             responseText: '{"url":"http://localhost:8000/api/users/42/","username":"Travis"}',
             status: 201,
         });
+
+        Logger.setDebug();
     });
 
     afterEach(function() {
@@ -56,7 +58,7 @@ describe("A RESTApiDatabaseAdapter", function() {
     });
 
     it("cannot post to the API when not initialized", function() {
-        spyOn(console, "log"); // suppress console warnings
+        spyOn(Logger, "_log"); // suppress Logger logs of all levels
         delete adapter;
         adapter = new RESTApiDatabaseAdapter("http://localhost:8000", 1, 1);
 
@@ -74,7 +76,7 @@ describe("A RESTApiDatabaseAdapter", function() {
     });
 
     it("can be set to debug mode", function() {
-        const consoleSpy = spyOn(console, "log");
+        const consoleSpy = spyOn(Logger, "debug");
 
         adapter.setDebug();
 
@@ -86,7 +88,6 @@ describe("A RESTApiDatabaseAdapter", function() {
         });
 
         expect(consoleSpy).toHaveBeenCalledTimes(2);
-        expect(consoleSpy.calls.all()[0].args[0]).toBe("Sent out AJAX request: ");
-        expect(consoleSpy.calls.all()[1].args[0]).toBe("Call success, status: success");
+        expect(consoleSpy.calls.all()[0].args[0]).toBe("Call success, status: success");
     });
 });

--- a/src/octopeer-github/test/LoggerTest.ts
+++ b/src/octopeer-github/test/LoggerTest.ts
@@ -1,0 +1,33 @@
+/**
+ * Created by Maarten on 18-05-2016.
+ */
+
+describe("The Logger", function() {
+
+    let consoleSpy: jasmine.Spy;
+
+    beforeEach(function() {
+        consoleSpy = spyOn(console, "log");
+        consoleSpy.calls.reset();
+        Logger.setDebug(false);
+    });
+
+    it("should log warnings", function() {
+        Logger.log("this is a warning");
+        expect(consoleSpy).toHaveBeenCalledWith("[WARN ] ", "this is a warning");
+    });
+
+    it("should log not debug messages", function() {
+        Logger.debug("this is a debug message");
+        expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    it("should log debug messages when it is set to debug mode", function() {
+        Logger.setDebug();
+        Logger.debug("this is a debug message");
+        expect(consoleSpy).toHaveBeenCalledWith("[DEBUG] ", "this is a debug message");
+
+        Logger.setDebug(false); // cleanup
+    });
+
+});

--- a/src/octopeer-github/test/LoggerTest.ts
+++ b/src/octopeer-github/test/LoggerTest.ts
@@ -13,7 +13,7 @@ describe("The Logger", function() {
     });
 
     it("should log warnings", function() {
-        Logger.log("this is a warning");
+        Logger.warn("this is a warning");
         expect(consoleSpy).toHaveBeenCalledWith("[WARN ] ", "this is a warning");
     });
 

--- a/src/octopeer-github/test/LoggerTest.ts
+++ b/src/octopeer-github/test/LoggerTest.ts
@@ -30,4 +30,10 @@ describe("The Logger", function() {
         Logger.setDebug(false); // cleanup
     });
 
+    it("should log database items", function() {
+        const obj = {data: "dummy"};
+        Logger.database(obj);
+        expect(consoleSpy).toHaveBeenCalledWith("[DATA ] ", obj);
+    });
+
 });

--- a/src/octopeer-github/test/_ref.ts
+++ b/src/octopeer-github/test/_ref.ts
@@ -1,1 +1,2 @@
 /// <reference path="../../../typings/main.d.ts"/>
+/// <reference path="../main/Logger.ts"/>

--- a/src/octopeer-github/tsconfig.json
+++ b/src/octopeer-github/tsconfig.json
@@ -9,5 +9,9 @@
     "outFile": "../../build/test.js",
     "target": "es5",
     "sourceMap": true
-  }
+  },
+  "exclude": [
+    "main/main.ts",
+    "content/main.ts"
+  ]
 }


### PR DESCRIPTION
Will close #33 

I implemented a Logger class. It is used instead of the `console.log` calls. It adds some 5-character-long tags to our log, like `[WARN ]` or `[DEBUG]`. The `ConsoleLogDatabaseAdapter` also uses the logger and has the tag `[DATA ]`. 
The debug messages are not enabled by default. If you call `Logger.setDebug()` (either in code or in the console), the debug messages will be shown after that point.

Let your feedback flow over me! :smile: 