### PR TITLE
49 Code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ before_script:
 script:
   - npm test                # Run the tests
 
+after_script:
+  - npm run-script coveralls
+
 notifications:
   email: false
   slack: tud-contextproject-16:7oE95aUGOwGTYonAvcVxYcGr

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ContextProject_RDD
 [![Stories in Ready](https://badge.waffle.io/thervh70/ContextProject_RDD.png?label=ready&title=Ready)](http://waffle.io/thervh70/ContextProject_RDD)
 [![Build Status](https://travis-ci.org/thervh70/ContextProject_RDD.svg?branch=master)](https://travis-ci.org/thervh70/ContextProject_RDD)
+[![Coverage Status](https://coveralls.io/repos/github/thervh70/ContextProject_RDD/badge.svg?branch=master)](https://coveralls.io/github/thervh70/ContextProject_RDD?branch=master)
 
 ### Documents
 - [Definition of Done](https://github.com/thervh70/ContextProject_RDD/blob/master/doc/Definition_of_Done.pdf)

--- a/README.md
+++ b/README.md
@@ -52,15 +52,13 @@ The default settings within this enabled area are sufficient, so apply the chang
 
 You've now activated TSLint.
 
+### Coverage
+- Run 'npm run-script travis' to generate a 'coverage-final' json file, if you haven't done so already.
+- Run 'npm run-script coverage' to generate a html coverage report of the json coverage file.
 
-**Installing and using MaDGe (dependency tool):**
-- Run `npm install madge` (library)
-- Run `npm -g install madge` (command-line tool)
-- Run `madge` for using MaDGe (it will return all options)
-- Run (for example) `madge -f amd -c ./src` for checking circular dependencies within the source code.
-- (Optional) GraphViz can be used for visualizing the results.
+You can now view the coverage report by opening the html file.
 
-More examples can be found [here](https://github.com/pahen/madge).
+This html file gives a nice overview of the coverage of the source code.
 
 ### Building and Installing the Extension
 - Run `build.sh` to build the extension

--- a/README.md
+++ b/README.md
@@ -53,12 +53,9 @@ The default settings within this enabled area are sufficient, so apply the chang
 You've now activated TSLint.
 
 ### Coverage
-- Run `npm run-script test` to generate a 'coverage-final' json file, if you haven't done so already (via `npm run-script travis`).
+- The `npm test` command will generate a `coverage-final.json` file.
 - Run `npm run-script coverage` to generate a html coverage report of the json coverage file.
-
-You can now view the coverage report by opening the html file.
-
-This html file gives a nice overview of the coverage of the source code.
+- You can now view the coverage report by opening `coverage/html/index.html`. This html file gives a nice overview of the coverage of the source code.
 
 ### Building and Installing the Extension
 - Run `build.sh` to build the extension

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ The default settings within this enabled area are sufficient, so apply the chang
 You've now activated TSLint.
 
 ### Coverage
-- Run 'npm run-script travis' to generate a 'coverage-final' json file, if you haven't done so already.
-- Run 'npm run-script coverage' to generate a html coverage report of the json coverage file.
+- Run `npm run-script test` to generate a 'coverage-final' json file, if you haven't done so already (via `npm run-script travis`).
+- Run `npm run-script coverage` to generate a html coverage report of the json coverage file.
 
 You can now view the coverage report by opening the html file.
 

--- a/karma.config.js
+++ b/karma.config.js
@@ -3,7 +3,7 @@ module.exports = function(config) {
     var configuration = {
         basePath: '.',
         frameworks: ['jasmine'],
-        plugins: ['karma-remap-istanbul'],
+        // plugins: ['karma-remap-istanbul'],
         files: [
             "node_modules/jquery/dist/jquery.min.js",
             "node_modules/jasmine-ajax/lib/mock-ajax.js",
@@ -12,19 +12,20 @@ module.exports = function(config) {
         ],
         reporters: ['progress', 'coverage', 'karma-remap-istanbul'],
         coverageReporter: {
-            type: 'html',
-            dir: 'coverage/'
+            type : 'json',
+            subdir : '.',
+            file : 'coverage-final.json'
         },
 
-        remapIstanbulReporter: {
-            src: 'coverage/report.json',
-            reports: {
-                lcovonly: 'coverage/',
-                html: 'coverage/'
-            },
-            timeoutNotCreated: 1000, // default value
-            timeoutNoMoreFiles: 1000 // default value
-        },
+        // remapIstanbulReporter: {
+        //     src: 'coverage/coverage-final.json',
+        //     reports: {
+        //         lcovonly: 'coverage/',
+        //         html: 'coverage/'
+        //     },
+        //     timeoutNotCreated: 1000, // default value
+        //     timeoutNoMoreFiles: 1000 // default value
+        // },
 
         preprocessors: {
             // source files, that you wanna generate coverage for

--- a/karma.config.js
+++ b/karma.config.js
@@ -9,14 +9,11 @@ module.exports = function(config) {
             "node_modules/jasmine-jquery/lib/jasmine-jquery.js",
             "build/test.js"
         ],
-        reporters: ['progress', 'coverage'/*, 'karma-remap-istanbul'*/],
+        reporters: ['progress', 'coverage'],
         coverageReporter: {
             type : 'json',
             subdir : '.',
-            file : 'coverage-final.json',
-            instrumenterOptions: {
-                istanbul: { noCompact: true }
-            }
+            file : 'coverage-final.json'
         },
 
         preprocessors: {

--- a/karma.config.js
+++ b/karma.config.js
@@ -14,7 +14,10 @@ module.exports = function(config) {
         coverageReporter: {
             type : 'json',
             subdir : '.',
-            file : 'coverage-final.json'
+            file : 'coverage-final.json',
+            instrumenterOptions: {
+                istanbul: { noCompact: true }
+            }
         },
 
         // remapIstanbulReporter: {

--- a/karma.config.js
+++ b/karma.config.js
@@ -3,14 +3,13 @@ module.exports = function(config) {
     var configuration = {
         basePath: '.',
         frameworks: ['jasmine'],
-        // plugins: ['karma-remap-istanbul'],
         files: [
             "node_modules/jquery/dist/jquery.min.js",
             "node_modules/jasmine-ajax/lib/mock-ajax.js",
             "node_modules/jasmine-jquery/lib/jasmine-jquery.js",
             "build/test.js"
         ],
-        reporters: ['progress', 'coverage', 'karma-remap-istanbul'],
+        reporters: ['progress', 'coverage'/*, 'karma-remap-istanbul'*/],
         coverageReporter: {
             type : 'json',
             subdir : '.',
@@ -20,21 +19,10 @@ module.exports = function(config) {
             }
         },
 
-        // remapIstanbulReporter: {
-        //     src: 'coverage/coverage-final.json',
-        //     reports: {
-        //         lcovonly: 'coverage/',
-        //         html: 'coverage/'
-        //     },
-        //     timeoutNotCreated: 1000, // default value
-        //     timeoutNoMoreFiles: 1000 // default value
-        // },
-
         preprocessors: {
             // source files, that you wanna generate coverage for
             // do not include tests or libraries
-            'build/content.js': ['coverage'],
-            'build/main.js': ['coverage']
+            'build/test.js': ['coverage']
         },
 
         browsers: ['Chrome', 'ChromeCanary'],

--- a/karma.config.js
+++ b/karma.config.js
@@ -3,16 +3,27 @@ module.exports = function(config) {
     var configuration = {
         basePath: '.',
         frameworks: ['jasmine'],
+        plugins: ['karma-remap-istanbul'],
         files: [
             "node_modules/jquery/dist/jquery.min.js",
             "node_modules/jasmine-ajax/lib/mock-ajax.js",
             "node_modules/jasmine-jquery/lib/jasmine-jquery.js",
             "build/test.js"
         ],
-        reporters: ['progress', 'coverage'],
+        reporters: ['progress', 'coverage', 'karma-remap-istanbul'],
         coverageReporter: {
             type: 'html',
             dir: 'coverage/'
+        },
+
+        remapIstanbulReporter: {
+            src: 'coverage/report.json',
+            reports: {
+                lcovonly: 'coverage/',
+                html: 'coverage/'
+            },
+            timeoutNotCreated: 1000, // default value
+            timeoutNoMoreFiles: 1000 // default value
         },
 
         preprocessors: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jquery": "^2.2.3",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.3",
-    "karma-coverage": "^1.0.0",
+    "karma-coverage": "^0.5.5",
     "karma-jasmine": "^0.3.8",
     "karma-remap-istanbul": "0.0.5",
     "materialize-css": "^0.97.6",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "license": "none",
   "scripts": {
+    "coverage": "remap-istanbul -i coverage/coverage-final.json -o coverage/html -t html",
+    "coveralls": "remap-istanbul -i coverage/coverage-final.json -t text-lcov | coveralls",
     "postinstall": "npm install -g typings && typings install",
     "test": "karma start karma.config.js --single-run --browsers Chrome",
     "travis": "npm run-script tslint && npm run-script tsc && npm test",
@@ -15,7 +17,7 @@
     "tslint": "tslint -c tslint.json src/**/*.ts"
   },
   "devDependencies": {
-    "intern": "^3.2.1",
+    "coveralls": "^2.11.9",
     "jasmine": "^2.4.1",
     "jasmine-ajax": "^3.2.0",
     "jasmine-jquery": "^2.1.1",
@@ -24,7 +26,6 @@
     "karma-chrome-launcher": "^0.2.3",
     "karma-coverage": "^0.5.5",
     "karma-jasmine": "^0.3.8",
-    "karma-remap-istanbul": "0.0.5",
     "materialize-css": "^0.97.6",
     "remap-istanbul": "^0.6.4",
     "tslint": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jquery": "^2.2.3",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.3",
-    "karma-coverage": "^0.5.5",
+    "karma-coverage": "^1.0.0",
     "karma-jasmine": "^0.3.8",
     "karma-remap-istanbul": "0.0.5",
     "materialize-css": "^0.97.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postinstall": "npm install -g typings && typings install",
     "test": "karma start karma.config.js --single-run --browsers Chrome",
     "travis": "npm run-script tslint && npm run-script tsc && npm test",
-    "tsc": "tsc --project src/octopeer-github/main && tsc --project src/octopeer-github/content && tsc --project src/octopeer-github/test",
+    "tsc": "tsc --project src/octopeer-github/main && tsc --project src/octopeer-github/content && tsc --project src/octopeer-github",
     "tslint": "tslint -c tslint.json src/**/*.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tslint": "tslint -c tslint.json src/**/*.ts"
   },
   "devDependencies": {
+    "intern": "^3.2.1",
     "jasmine": "^2.4.1",
     "jasmine-ajax": "^3.2.0",
     "jasmine-jquery": "^2.1.1",
@@ -23,7 +24,9 @@
     "karma-chrome-launcher": "^0.2.3",
     "karma-coverage": "^0.5.5",
     "karma-jasmine": "^0.3.8",
+    "karma-remap-istanbul": "0.0.5",
     "materialize-css": "^0.97.6",
+    "remap-istanbul": "^0.6.4",
     "tslint": "^3.9.0",
     "typescript": "^1.8.10",
     "typings": "^0.8.1"

--- a/src/octopeer-github/_ref.ts
+++ b/src/octopeer-github/_ref.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../typings/main.d.ts"/>

--- a/src/octopeer-github/content/ContentController.ts
+++ b/src/octopeer-github/content/ContentController.ts
@@ -93,15 +93,7 @@ class ContentController {
      * An inner singleton class that implements DatabaseAdaptable in order to send messages to the background page.
      * @type {MessageSendDatabaseAdapter}
      */
-    private messageSendDatabaseAdapter = new (class MessageSendDatabaseAdapter implements DatabaseAdaptable {
-        public post(data: EventObject, success: Callback, failure: Callback) {
-            let postData: any = data;
-            postData.elementID = (<ElementID>data.elementID).getElementID();
-            postData.eventID = (<EventID>data.eventID).getEventID();
-            chrome.runtime.sendMessage(JSON.stringify(postData));
-            success();
-        }
-    })();
+    private messageSendDatabaseAdapter = new MessageSendDatabaseAdapter();
 
     /**
      * Starts the ContentController. After calling this, all event handlers are hooked to the DOM-tree.

--- a/src/octopeer-github/content/DatabaseAdaptable/MessageSendDatabaseAdapter.ts
+++ b/src/octopeer-github/content/DatabaseAdaptable/MessageSendDatabaseAdapter.ts
@@ -1,0 +1,22 @@
+/**
+ * Created by Maarten on 17-05-2016.
+ */
+
+/**
+ * This class implements DatabaseAdaptable in a way that
+ * the data is sent to the Chrome Extension Background page.
+ */
+class MessageSendDatabaseAdapter implements DatabaseAdaptable {
+
+    /**
+     * @see ../../main/DatabaseAdaptable
+     */
+    public post(data: EventObject, success: Callback, failure: Callback) {
+        let postData: any = data;
+        postData.elementID = (<ElementID>data.elementID).getElementID();
+        postData.eventID = (<EventID>data.eventID).getEventID();
+        chrome.runtime.sendMessage(JSON.stringify(postData));
+        success();
+    }
+
+}

--- a/src/octopeer-github/test/_ref.ts
+++ b/src/octopeer-github/test/_ref.ts
@@ -1,1 +1,0 @@
-/// <reference path="../../../typings/main.d.ts"/>

--- a/src/octopeer-github/tsconfig.json
+++ b/src/octopeer-github/tsconfig.json
@@ -6,7 +6,7 @@
     "noImplicitAny": true,
     "removeComments": true,
     "preserveConstEnums": true,
-    "outFile": "../../../build/test.js",
+    "outFile": "../../build/test.js",
     "target": "es5",
     "sourceMap": true
   }

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -1,0 +1,53 @@
+// Learn more about configuring this file at <https://theintern.github.io/intern/#configuration>.
+// These default settings work OK for most people. The options that *must* be changed below are the packages, suites,
+// excludeInstrumentation, and (if you want functional tests) functionalSuites
+define({
+	// Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
+	// specified browser environments in the `environments` array below as well. See
+	// <https://theintern.github.io/intern/#option-capabilities> for links to the different capabilities options for
+	// different services.
+	//
+	// Note that the `build` capability will be filled in with the current commit ID or build tag from the CI
+	// environment automatically
+	capabilities: {
+		'browserstack.selenium_version': '2.45.0'
+	},
+
+	// Browsers to run integration testing against. Options that will be permutated are browserName, version, platform,
+	// and platformVersion; any other capabilities options specified for an environment will be copied as-is. Note that
+	// browser and platform names, and version number formats, may differ between cloud testing systems.
+	environments: [
+		{ browserName: 'internet explorer', version: '11', platform: 'WIN8' },
+		{ browserName: 'internet explorer', version: '10', platform: 'WIN8' },
+		{ browserName: 'internet explorer', version: '9', platform: 'WINDOWS' },
+		{ browserName: 'firefox', version: '37', platform: [ 'WINDOWS', 'MAC' ] },
+		{ browserName: 'chrome', version: '39', platform: [ 'WINDOWS', 'MAC' ] },
+		{ browserName: 'safari', version: '8', platform: 'MAC' }
+	],
+
+	// Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
+	maxConcurrency: 2,
+
+	// Name of the tunnel class to use for WebDriver tests.
+	// See <https://theintern.github.io/intern/#option-tunnel> for built-in options
+	tunnel: 'BrowserStackTunnel',
+
+	// Configuration options for the module loader; any AMD configuration options supported by the AMD loader in use
+	// can be used here.
+	// If you want to use a different loader than the default loader, see
+	// <https://theintern.github.io/intern/#option-useLoader> for more information.
+	loaderOptions: {
+		// Packages that should be registered with the loader in each testing environment
+		packages: [ { name: 'myPackage', location: '.' } ]
+	},
+
+	// Unit test suite(s) to run in each browser
+	suites: [ /* 'myPackage/tests/foo', 'myPackage/tests/bar' */ ],
+
+	// Functional test suite(s) to execute against each browser once unit tests are completed
+	functionalSuites: [ /* 'myPackage/tests/functional' */ ],
+
+	// A regular expression matching URLs to files that should not be included in code coverage analysis. Set to `true`
+	// to completely disable code coverage.
+	excludeInstrumentation: /^(?:tests|node_modules)\//
+});


### PR DESCRIPTION
Will close #49 

I represent you: a coverage report as a html file in the repo and a new coverage tool and bot 'coveralls'.

Changes:
- A few new commands have been added that can be used via 'npm run-script ....'. Please read the updated readme file for this.
- A html file will be generated when running the needed script. This file gives a nice overview of the coverage of the source code.
- We have a new bot on the private Slack channel; 'coveralls', as you may have noticed.

Thanks @mpsijm for helping me out on the last few errors I had. :)
As there was little documentation (the tools are relatively new), it took quite some time to get this working.

Please review :)

Please note that the new command 'npm run-script coveralls' doesn't need any attention. It's just there to notify the Coveralls tool.