### PR TITLE
Split MainController.connectToContent into four delegate methods

### DIFF
--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -37,8 +37,15 @@ class MainController {
             }
         });
         // Whenever a tab updates, send a message to re-hook to DOM
+        chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+            if (changeInfo.status && changeInfo.status === "complete") {
+                self.testAndSend(tab);
+            }
+        });
+        // Whenever the user changes tabs, send a message to re-hook to DOM
         chrome.tabs.onActivated.addListener( function(activeInfo) {
             chrome.tabs.query({"active": true, "windowId": activeInfo.windowId}, function (tabs: Tab[]) {
+                // There is usually only one active tab, so no need to iterate
                 self.testAndSend(tabs[0]);
             });
         });

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -18,6 +18,7 @@ class MainController {
         this.database = new ConsoleLogDatabaseAdapter(); // ("https://localhost:8000", 1, 1);
         this.connectToContentScript();
         Status.standby();
+        // TODO: Options.update actually means "add a listener to the storage" so can be merged into init
         Options.init();
         Options.update();
         Options.addObserver(Status);
@@ -28,28 +29,55 @@ class MainController {
      * Set up all event handlers in the Chrome API.
      */
     private connectToContentScript() {
+        this.initAllCurrentTabs();
+        this.rehookOnUpdate();
+        this.rehookOnFocusChange();
+        this.listenToDatabaseMessages();
+    }
+
+    /**
+     * On start-up, let all tabs hook to DOM
+     */
+    private initAllCurrentTabs() {
         const self = this;
-        // On start-up, let all tabs hook to DOM
         chrome.tabs.query({}, function(tabs) {
             let tab: Tab;
             for (tab of tabs) {
                 self.testAndSend(tab);
             }
         });
-        // Whenever a tab updates, send a message to re-hook to DOM
+    }
+
+    /**
+     * Whenever a tab updates, send a message to re-hook to DOM
+     */
+    private rehookOnUpdate() {
+        const self = this;
         chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
             if (changeInfo.status && changeInfo.status === "complete") {
                 self.testAndSend(tab);
             }
         });
-        // Whenever the user changes tabs, send a message to re-hook to DOM
-        chrome.tabs.onActivated.addListener( function(activeInfo) {
+    }
+
+    /**
+     * Whenever the user changes tabs, send a message to re-hook to DOM
+     */
+    private rehookOnFocusChange() {
+        const self = this;
+        chrome.tabs.onActivated.addListener(function(activeInfo) {
             chrome.tabs.query({"active": true, "windowId": activeInfo.windowId}, function (tabs: Tab[]) {
                 // There is usually only one active tab, so no need to iterate
                 self.testAndSend(tabs[0]);
             });
         });
-        // When a tab sends a message, log it to the Database
+    }
+
+    /**
+     * When a tab sends a message, log it to the Database
+     */
+    private listenToDatabaseMessages() {
+        const self = this;
         chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
             if (!sender.tab) {
                 return; // Only continue if message is sent from a content script

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -37,10 +37,10 @@ class MainController {
             }
         });
         // Whenever a tab updates, send a message to re-hook to DOM
-        chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
-            if (changeInfo.status && changeInfo.status === "complete") {
-                self.testAndSend(tab);
-            }
+        chrome.tabs.onActivated.addListener( function(activeInfo) {
+            chrome.tabs.query({"active": true, "windowId": activeInfo.windowId}, function (tabs: Tab[]) {
+                self.testAndSend(tabs[0]);
+            });
         });
         // When a tab sends a message, log it to the Database
         chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -36,7 +36,7 @@ class MainController {
     }
 
     /**
-     * On start-up, let all tabs hook to DOM
+     * On start-up, let all tabs hook to DOM.
      */
     private initAllCurrentTabs() {
         const self = this;
@@ -49,7 +49,7 @@ class MainController {
     }
 
     /**
-     * Whenever a tab updates, send a message to re-hook to DOM
+     * Whenever a tab updates, send a message to re-hook to DOM.
      */
     private rehookOnUpdate() {
         const self = this;
@@ -61,20 +61,20 @@ class MainController {
     }
 
     /**
-     * Whenever the user changes tabs, send a message to re-hook to DOM
+     * Whenever the user changes tabs, send a message to re-hook to DOM.
+     * There is usually only one active tab, so no need to iterate in the callback.
      */
     private rehookOnFocusChange() {
         const self = this;
         chrome.tabs.onActivated.addListener(function(activeInfo) {
             chrome.tabs.query({"active": true, "windowId": activeInfo.windowId}, function (tabs: Tab[]) {
-                // There is usually only one active tab, so no need to iterate
                 self.testAndSend(tabs[0]);
             });
         });
     }
 
     /**
-     * When a tab sends a message, log it to the Database
+     * When a tab sends a message, log it to the Database.
      */
     private listenToDatabaseMessages() {
         const self = this;


### PR DESCRIPTION
Conform the feedback from Bastiaan, I split `MainController.connectToContent` into four delegate methods.
Should not be much to review, but #77 (Issue #66) should be merged before this branch :)