### PR TITLE
91 Refactored saveOptions method

### DIFF
--- a/resources/options.js
+++ b/resources/options.js
@@ -17,26 +17,18 @@ function changeListener() {
 // Saves options to chrome.storage.
 // A message will confirm this to the user.
 function saveOptions() {
-    var logging = $('#logging').prop('checked');
-    var tabs = $('#tabs').prop('checked');
-    var comments = $('#comments').prop('checked');
-    var peerComments = $('#peerComments').prop('checked');
-    var focus = $('#focus').prop('checked');
-    var username = $('#username').prop('checked');
-    var repo = $('#repo').prop('checked');
-    var file = $('#file').prop('checked');
     chrome.storage.sync.set({
         // General
-        loggingEnabled: logging,
+        loggingEnabled: $('#logging').prop('checked'),
         // Privacy
-        trackTabs: tabs,
-        trackComments: comments,
-        trackPeerComments: peerComments,
-        trackFocus: focus,
+        trackTabs: $('#tabs').prop('checked'),
+        trackComments:  $('#comments').prop('checked'),
+        trackPeerComments: $('#peerComments').prop('checked'),
+        trackFocus: $('#focus').prop('checked'),
         // Security
-        hashUsername: username,
-        hashRepo: repo,
-        hashFile: file
+        hashUsername: $('#username').prop('checked'),
+        hashRepo: $('#repo').prop('checked'),
+        hashFile: $('#file').prop('checked')
         // Hints
     }, function() {
         Materialize.toast("Options saved!", 2000);


### PR DESCRIPTION
Will close #91

This frontend class had long methods according to SIG. I have refactored 1, but was not able to refactor the other (`restoreOptionsState`) because it must get the items first based on the key before it can use the values. Putting all keys on a single line would decrease readability.

Just a single commit PR.