### PR TITLE
106 rawdata switch

### DIFF
--- a/src/octopeer-github/main/Database/ConsoleLogDatabaseAdapter.ts
+++ b/src/octopeer-github/main/Database/ConsoleLogDatabaseAdapter.ts
@@ -5,16 +5,17 @@
 class ConsoleLogDatabaseAdapter implements DatabaseAdaptable {
 
     /**
-     * Simple boolean to keep track of the raw data output.
+     * Simple boolean to keep track of the raw data logging.
      */
-    private static outputRawData = true;
+    private static rawDataLogging = true;
 
     /**
      * Set the raw data switch for the console.
-     * @bool the new value.
+     * By default the console will show raw data.
+     * @logging the new value.
      */
-    public static setRawData(bool: boolean) {
-        ConsoleLogDatabaseAdapter.outputRawData = bool;
+    public static setRawData(logging = true) {
+        ConsoleLogDatabaseAdapter.rawDataLogging = logging;
     }
 
     /**
@@ -22,7 +23,7 @@ class ConsoleLogDatabaseAdapter implements DatabaseAdaptable {
      * @returns raw data value.
      */
     public static getRawData() {
-        return ConsoleLogDatabaseAdapter.outputRawData;
+        return ConsoleLogDatabaseAdapter.rawDataLogging;
     }
 
     /**
@@ -69,9 +70,12 @@ class ConsoleLogDatabaseAdapter implements DatabaseAdaptable {
 
     /**
      * Raw data filter method.
+     * It checks whether the raw data logging is enabled and will then output the eventdata.
+     * If the raw data logging is disabled this method will do nothing.
+     * @param eventData The data that will be passed
      */
-    public filterRawData(eventData: any) {
-        if (ConsoleLogDatabaseAdapter.outputRawData) {
+    private filterRawData(eventData: any) {
+        if (ConsoleLogDatabaseAdapter.rawDataLogging) {
             Logger.database(eventData);
         }
     }

--- a/src/octopeer-github/main/Database/ConsoleLogDatabaseAdapter.ts
+++ b/src/octopeer-github/main/Database/ConsoleLogDatabaseAdapter.ts
@@ -1,10 +1,29 @@
 /**
  * Created by Youri on 04/05/2016.
- */
-/**
  * Semi-mock class for being able to check implementation completeness.
  */
 class ConsoleLogDatabaseAdapter implements DatabaseAdaptable {
+
+    /**
+     * Simple boolean to keep track of the raw data output.
+     */
+    private static outputRawData = true;
+
+    /**
+     * Set the raw data switch for the console.
+     * @bool the new value.
+     */
+    public static setRawData(bool: boolean) {
+        ConsoleLogDatabaseAdapter.outputRawData = bool;
+    }
+
+    /**
+     * Get raw data value.
+     * @returns raw data value.
+     */
+    public static getRawData() {
+        return ConsoleLogDatabaseAdapter.outputRawData;
+    }
 
     /**
      * @param eventData The data to log to the console.
@@ -17,35 +36,44 @@ class ConsoleLogDatabaseAdapter implements DatabaseAdaptable {
      * @param eventData The data to log to the console.
      */
     public postKeystroke(eventData: IKeystrokeEvent) {
-        Logger.database(eventData);
+        this.filterRawData(eventData);
     }
 
     /**
      * @param eventData The data to log to the console.
      */
     public postMousePosition(eventData: IMousePositionEvent) {
-        Logger.database(eventData);
+        this.filterRawData(eventData);
     }
 
     /**
      * @param eventData The data to log to the console.
      */
     public postMouseClick(eventData: IMouseClickEvent) {
-        Logger.database(eventData);
+        this.filterRawData(eventData);
     }
 
     /**
      * @param eventData The data to log to the console.
      */
     public postMouseScroll(eventData: IMouseScrollEvent) {
-        Logger.database(eventData);
+        this.filterRawData(eventData);
     }
 
     /**
      * @param eventData The data to log to the console.
      */
     public postWindowResolution(eventData: IWindowResolutionEvent) {
-        Logger.database(eventData);
+        this.filterRawData(eventData);
+    }
+
+    /**
+     * Raw data filter method.
+     */
+    public filterRawData(eventData: any) {
+        if (ConsoleLogDatabaseAdapter.outputRawData) {
+            Logger.database(eventData);
+        }
     }
 
 }

--- a/src/octopeer-github/main/Database/ConsoleLogDatabaseAdapter.ts
+++ b/src/octopeer-github/main/Database/ConsoleLogDatabaseAdapter.ts
@@ -14,15 +14,15 @@ class ConsoleLogDatabaseAdapter implements DatabaseAdaptable {
      * By default the console will show raw data.
      * @logging the new value.
      */
-    public static setRawData(logging = true) {
+    public static setRawDataLogging(logging = true) {
         ConsoleLogDatabaseAdapter.rawDataLogging = logging;
     }
 
     /**
-     * Get raw data value.
-     * @returns raw data value.
+     * Get raw data logging value.
+     * @returns raw data logging value.
      */
-    public static getRawData() {
+    public static getRawDataLogging() {
         return ConsoleLogDatabaseAdapter.rawDataLogging;
     }
 

--- a/src/octopeer-github/test/main/Database/ConsoleLogDatabaseAdapterTest.ts
+++ b/src/octopeer-github/test/main/Database/ConsoleLogDatabaseAdapterTest.ts
@@ -4,17 +4,80 @@
  */
 
 describe("The ConsoleLogDatabaseAdapter", function() {
-    let data: ISemanticEvent;
     let CLDAdapter: DatabaseAdaptable;
     let spy: jasmine.Spy;
 
-    it("should 'post' data to the console by calling the post function", function () {
+    beforeEach(function() {
         CLDAdapter = new ConsoleLogDatabaseAdapter();
-        data = new SemanticEvent(defaultElementID, defaultEventID, new Date().getTime(), 42);
         spy = spyOn(Logger, "database");
+    });
+
+    it("should 'post' data to the console by calling the post function", function () {
+        const data = new SemanticEvent(defaultElementID, defaultEventID, new Date().getTime(), 42);
         CLDAdapter.postSemantic(data, EMPTY_CALLBACK, EMPTY_CALLBACK);
 
         expect(spy).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledWith(data);
+    });
+
+    it("should 'post' a keystroke event", function () {
+        const data = new KeystrokeEvent("0", 0);
+        CLDAdapter.postKeystroke(data, EMPTY_CALLBACK, EMPTY_CALLBACK);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith(data);
+    });
+
+    it("should 'post' a mouse position event", function () {
+        const data = new MousePositionEvent(0, 0, 0, 0, 0);
+        CLDAdapter.postMousePosition(data, EMPTY_CALLBACK, EMPTY_CALLBACK);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith(data);
+    });
+
+    it("should 'post' a mouse click event", function () {
+        const data = new MouseClickEvent(0);
+        CLDAdapter.postMouseClick(data, EMPTY_CALLBACK, EMPTY_CALLBACK);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith(data);
+    });
+
+    it("should 'post' a mouse scroll event", function () {
+        const data = new MouseScrollEvent(0, 0, 0);
+        CLDAdapter.postMouseScroll(data, EMPTY_CALLBACK, EMPTY_CALLBACK);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith(data);
+    });
+
+    it("should 'post' a window resize event", function () {
+        const data = new WindowResolutionEvent(0, 0, 0);
+        CLDAdapter.postWindowResolution(data, EMPTY_CALLBACK, EMPTY_CALLBACK);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith(data);
+    });
+
+    it("should output the raw data by default", function () {
+        expect(ConsoleLogDatabaseAdapter.getRawData()).toBe(true);
+    });
+
+    it("should correctly set a new value", function () {
+        expect(ConsoleLogDatabaseAdapter.getRawData()).toBe(true);
+
+        ConsoleLogDatabaseAdapter.setRawData(false);
+
+        expect(ConsoleLogDatabaseAdapter.getRawData()).toBe(false);
+    });
+
+    it("should filter if the output is disabled", function () {
+        ConsoleLogDatabaseAdapter.setRawData(false);
+
+        const data = new WindowResolutionEvent(0, 0, 0);
+        CLDAdapter.postWindowResolution(data, EMPTY_CALLBACK, EMPTY_CALLBACK);
+
+        expect(spy).not.toHaveBeenCalled();
     });
 });

--- a/src/octopeer-github/test/main/Database/ConsoleLogDatabaseAdapterTest.ts
+++ b/src/octopeer-github/test/main/Database/ConsoleLogDatabaseAdapterTest.ts
@@ -61,19 +61,19 @@ describe("The ConsoleLogDatabaseAdapter", function() {
     });
 
     it("should output the raw data by default", function () {
-        expect(ConsoleLogDatabaseAdapter.getRawData()).toBe(true);
+        expect(ConsoleLogDatabaseAdapter.getRawDataLogging()).toBe(true);
     });
 
     it("should correctly set a new value", function () {
-        expect(ConsoleLogDatabaseAdapter.getRawData()).toBe(true);
+        expect(ConsoleLogDatabaseAdapter.getRawDataLogging()).toBe(true);
 
-        ConsoleLogDatabaseAdapter.setRawData(false);
+        ConsoleLogDatabaseAdapter.setRawDataLogging(false);
 
-        expect(ConsoleLogDatabaseAdapter.getRawData()).toBe(false);
+        expect(ConsoleLogDatabaseAdapter.getRawDataLogging()).toBe(false);
     });
 
     it("should filter if the output is disabled", function () {
-        ConsoleLogDatabaseAdapter.setRawData(false);
+        ConsoleLogDatabaseAdapter.setRawDataLogging(false);
 
         const data = new WindowResolutionEvent(0, 0, 0);
         CLDAdapter.postWindowResolution(data, EMPTY_CALLBACK, EMPTY_CALLBACK);


### PR DESCRIPTION
Will close #106

Added a boolean switch for filtering the raw data events in the console.
`ConsoleLogDatabaseAdapter.setRawData(false)` and the console data stream will be a lot cleaner.

Fully tested and ready to merge (if you guys approve).