### PR TITLE
136 Default Options Button

### DIFF
--- a/resources/main.css
+++ b/resources/main.css
@@ -1,11 +1,5 @@
 a {
-    color: white;
     font-family: Roboto,sans-serif;
-}
-
-button {
-    font-size: 11pt;
-    margin-bottom: 30px;
 }
 
 p {

--- a/resources/main.css
+++ b/resources/main.css
@@ -4,6 +4,7 @@ a {
 }
 
 button {
+    font-size: 11pt;
     margin-bottom: 30px;
 }
 

--- a/resources/main.css
+++ b/resources/main.css
@@ -1,3 +1,12 @@
+a {
+    color: white;
+    font-family: Roboto,sans-serif;
+}
+
+button {
+    margin-bottom: 30px;
+}
+
 p {
     font-family: Roboto,sans-serif;
     font-size: 12pt;

--- a/resources/options.html
+++ b/resources/options.html
@@ -159,7 +159,7 @@
 
     <button class="btn waves-effect lime waves-light" type="submit" id="restore">
         <div>
-            <a style="font-size: 11pt;">Restore Defaults</a>
+            <a>Restore Defaults</a>
             <i class="material-icons right">restore</i>
         </div>
     </button>

--- a/resources/options.html
+++ b/resources/options.html
@@ -156,6 +156,15 @@
     </div>
 
     </div>
+    <div id="restoreDefaults"></div>
+
+    <button class="btn waves-effect lime waves-light" type="submit" id="restore">
+        <div>
+            <a style="font-family: Roboto,sans-serif; font-size:11pt; color:white">Restore Defaults</a>
+            <i class="material-icons right">restore</i>
+        </div>
+    </button>
+
 </div>
 </body>
 </html>

--- a/resources/options.html
+++ b/resources/options.html
@@ -156,7 +156,6 @@
     </div>
 
     </div>
-    <div id="restoreDefaults"></div>
 
     <button class="btn waves-effect lime waves-light" type="submit" id="restore">
         <div>

--- a/resources/options.html
+++ b/resources/options.html
@@ -159,7 +159,7 @@
 
     <button class="btn waves-effect lime waves-light" type="submit" id="restore">
         <div>
-            <a style="font-family: Roboto,sans-serif; font-size:11pt; color:white">Restore Defaults</a>
+            <a style="font-size: 11pt;">Restore Defaults</a>
             <i class="material-icons right">restore</i>
         </div>
     </button>

--- a/resources/options.html
+++ b/resources/options.html
@@ -157,9 +157,9 @@
 
     </div>
 
-    <button class="btn waves-effect lime waves-light" type="submit" id="restore">
+    <button class="btn waves-effect lime waves-light" type="submit" style="font-size: 11pt; margin-bottom: 30px;" id="restore">
         <div>
-            <a>Restore Defaults</a>
+            <a style="color: white;">Restore Defaults</a>
             <i class="material-icons right">restore</i>
         </div>
     </button>

--- a/resources/options.js
+++ b/resources/options.js
@@ -15,6 +15,9 @@ var subOptions = ['securitySubOptions', 'privacySubOptions', 'hintsSubOptions', 
 // List that contains all cardElement names that Octopeer provides.
 var cards = ['security', 'privacy', 'hints', 'doNotWatch'];
 
+// Object that contains all default options.
+var defaultOptions = {};
+
 // Listens for changes in the loggingEnabled flag.
 // This boolean might be switched using the popup.
 function changeListener() {
@@ -153,11 +156,27 @@ function switchOptions() {
     }
 }
 
+// Saves the default options by saving an object.
+function saveDefaults() {
+    for (var i = 0; i < options.length; i++) {
+        defaultOptions[options[i]] = optionsElement(i).prop('checked');
+    }
+}
+
+// Sets the options to the default options by updating the chrome storage and the options page.
+function restoreDefaults() {
+    chrome.storage.sync.set(defaultOptions, function() {});
+    restoreOptionsState();
+    restoreOptionsAvailability();
+}
+
 document.addEventListener('DOMContentLoaded', restoreOptionsState);
 document.addEventListener('DOMContentLoaded', restoreOptionsAvailability);
 
 // Will execute once the page DOM is ready.
 $(document).ready(function() {
+    saveDefaults();
     addOptionClickEvents();
     changeListener();
+    $('#restore').click(restoreDefaults);
 });


### PR DESCRIPTION
Will close #136 

The restore default options button has been added.

The way I've implemented it is quite simple; an object is created based on the frontend defaults on initialisation. This object is used for updating the chrome storage and the checkboxes.

Please review this PR by rebuilding the extension and playing around with the new button. Tell me whether you like the button and whether you can detect any bugs.

Please note that in another PR all default options will be moved to the backend.