### PR TITLE
#32 Add MutationObserver to ContentController

### DIFF
--- a/src/octopeer-github/content/ContentController.ts
+++ b/src/octopeer-github/content/ContentController.ts
@@ -25,6 +25,13 @@ class ContentController {
      */
     private oldEventTrackers: EventTracker[] = [];
 
+    /**
+     * This MutationObserver will observer the DOM for mutations in the tree.
+     * On mutations, it will re-hook the ContentController to the DOM,
+     *     so that dynamically generated elements will also be tracked.
+     * The class MutationObserver is in the vanilla JavaScript libraries.
+     * @type {MutationObserver}
+     */
     private mutationObserver = new MutationObserver((mutationRecordList) => {
         /*for (let mutationRecord of mutationRecordList) {
             const addedNodes = mutationRecord.addedNodes;


### PR DESCRIPTION
Will (finally! :smile: ) close #32 

I let the ContentController use a [`MutationObserver`](https://developer.mozilla.org/en/docs/Web/API/MutationObserver) which makes sure the DOM gets re-hooked whenever children are added/deleted to the subtree.

Since we can also use this observer for #134, I left some commented code in which I might use for that issue. The code fetches all added nodes separately. This might (note: might) simplify the DOM-traversal when adding the `data-octopeer-*` tags. I will definitely remove this commented code in #134, whether I will use it or not.

Have fun reviewing, and especially try out this change by for example opening in-line comments and checking whether the elements inside the generated `<div>` are being tracked :)