### PR TITLE
137 update db adapter keystroke

### DIFF
--- a/src/octopeer-github/content/EventTracker/KeystrokeTracker.ts
+++ b/src/octopeer-github/content/EventTracker/KeystrokeTracker.ts
@@ -14,10 +14,10 @@ class KeystrokeTracker implements EventTracker {
      * Initiates this EventTracker to collect event data.
      */
     public addDOMEvent() {
-        $("body").on("keypress", (eventObject: JQueryEventObject) => {
-            this.db.post(EventFactory.keystroke(String.fromCharCode(eventObject.which),
-                // TODO: key_down_at and key_up_at should be set correctly.
-                EventFactory.getTime(), EventFactory.getTime()), EMPTY_CALLBACK, EMPTY_CALLBACK);
+        $("body").on("keydown", (eventObject: JQueryEventObject) => {
+            this.db.post(EventFactory.keyDown(eventObject.key), EMPTY_CALLBACK, EMPTY_CALLBACK);
+        }).on("keyup", (eventObject: JQueryEventObject) => {
+            this.db.post(EventFactory.keyUp(eventObject.key), EMPTY_CALLBACK, EMPTY_CALLBACK);
         });
     }
 
@@ -25,7 +25,7 @@ class KeystrokeTracker implements EventTracker {
      * Stops this EventTracker from collecting event data.
      */
     public removeDOMEvent() {
-        $("body").off("keypress");
+        $("body").off("keydown keyup");
     }
 
 }

--- a/src/octopeer-github/main/Database/EventObject/EventFactory.ts
+++ b/src/octopeer-github/main/Database/EventObject/EventFactory.ts
@@ -16,7 +16,7 @@ abstract class EventFactory {
      * @param filename      (optional) the filename in which an inline event is fired.
      * @param lineNumber    (optional) the line number in which an inline event is fired.
      * @param created_at    the timestamp at which the event was created. Defaults to the current timestamp.
-     * @returns {SemanticEvent} A SemanticEvent object that can be posted to the database.
+     * @returns {EventObject} A SemanticEvent object that can be posted to the database.
      */
     public static semantic(elementID: ElementID, eventID: EventID,
                            filename?: FileName, lineNumber?: LineNumber, created_at = EventFactory.getTime()): EventObject {
@@ -28,22 +28,42 @@ abstract class EventFactory {
 
     /**
      * Creates a KeystrokeEvent object.
-     * @param keystroke     the keystroke that is being logged.
-     * @param key_down_at   the timestamp when the key went down.
-     * @param key_up_at     the timestamp when the key went up.
-     * @returns {KeystrokeEvent} A KeystrokeEvent object that can be posted to the database.
+     * @param keystroke         the keystroke that is being logged.
+     * @param keystroke_type    the type of the keystroke (KEY_DOWN or KEY_UP)
+     * @param created_at        the timestamp when the keystroke was logged.
+     * @returns {EventObject} A KeystrokeEvent object that can be posted to the database.
      */
-    public static keystroke(keystroke: string, key_down_at: UnixTimestamp, key_up_at: UnixTimestamp): EventObject {
+    public static keystroke(keystroke: string, keystroke_type: KeystrokeType, created_at = EventFactory.getTime()): EventObject {
         return {
-            data: {key_down_at: key_down_at, key_up_at: key_up_at, keystroke: keystroke},
+            data: {created_at: created_at, keystroke: keystroke, keystroke_type: keystroke_type},
             type: "KeystrokeEvent",
         };
     }
 
     /**
+     * Creates a KeystrokeEvent object where the keystroke_type is set to KEY_DOWN.
+     * @param keystroke         the keystroke that is being logged.
+     * @param created_at        the timestamp when the keystroke was logged.
+     * @returns {EventObject} A KeystrokeEvent object that can be posted to the database.
+     */
+    public static keyDown(keystroke: string, created_at = EventFactory.getTime()) {
+        return EventFactory.keystroke(keystroke, KeystrokeType.KEY_DOWN, created_at);
+    }
+
+    /**
+     * Creates a KeystrokeEvent object where the keystroke_type is set to KEY_UP.
+     * @param keystroke         the keystroke that is being logged.
+     * @param created_at        the timestamp when the keystroke was logged.
+     * @returns {EventObject} A KeystrokeEvent object that can be posted to the database.
+     */
+    public static keyUp(keystroke: string, created_at = EventFactory.getTime()) {
+        return EventFactory.keystroke(keystroke, KeystrokeType.KEY_UP, created_at);
+    }
+
+    /**
      * Creates a MouseClickEvent object.
      * @param created_at    the timestamp at which the event was created. Defaults to the current timestamp.
-     * @returns {MouseClickEvent} A MouseClickEvent object that can be posted to the database.
+     * @returns {EventObject} A MouseClickEvent object that can be posted to the database.
      */
     public static mouseClick(created_at = EventFactory.getTime()): EventObject {
         return {
@@ -59,7 +79,7 @@ abstract class EventFactory {
      * @param viewport_x    the x-position of the mouse relative to the viewport.
      * @param viewport_y    the y-position of the mouse relative to the viewport.
      * @param created_at    the timestamp at which the event was created. Defaults to the current timestamp.
-     * @returns {MousePositionEvent} A MousePositionEvent object that can be posted to the database.
+     * @returns {EventObject} A MousePositionEvent object that can be posted to the database.
      */
     public static mousePosition(position_x: number, position_y: number,
                                 viewport_x: number, viewport_y: number, created_at = EventFactory.getTime()): EventObject {
@@ -75,7 +95,7 @@ abstract class EventFactory {
      * @param viewport_x    the x-position of the mouse relative to the viewport.
      * @param viewport_y    the y-position of the mouse relative to the viewport.
      * @param created_at    the timestamp at which the event was created. Defaults to the current timestamp.
-     * @returns {MouseScrollEvent} A MouseScrollEvent object that can be posted to the database.
+     * @returns {EventObject} A MouseScrollEvent object that can be posted to the database.
      */
     public static mouseScroll(viewport_x: number, viewport_y: number, created_at = EventFactory.getTime()): EventObject {
         return {
@@ -89,7 +109,7 @@ abstract class EventFactory {
      * @param width         the new width of the window.
      * @param height        the new height of the window.
      * @param created_at    the timestamp at which the event was created. Defaults to the current timestamp.
-     * @returns {WindowResolutionEvent} A WindowResolutionEvent object that can be posted to the database.
+     * @returns {EventObject} A WindowResolutionEvent object that can be posted to the database.
      */
     public static windowResolution(width: number, height: number, created_at = EventFactory.getTime()): EventObject {
         return {

--- a/src/octopeer-github/main/Database/EventObject/KeystrokeEvent.ts
+++ b/src/octopeer-github/main/Database/EventObject/KeystrokeEvent.ts
@@ -2,13 +2,19 @@
  * Created by Maarten on 26-05-2016.
  */
 
+const KeystrokeType = {
+    KEY_DOWN: 1,
+    KEY_UP: 2,
+};
+type KeystrokeType = number;
+
 /**
  * A KeystrokeEvent contains the data that should be posted to a Database.
  * @param keystroke     the keystroke that is being logged.
- * @param timestamp     when the event was created.
+ * @param created_at    when the event was created.
  */
 interface KeystrokeEvent {
     keystroke: string;
-    key_down_at: UnixTimestamp;
-    key_up_at: UnixTimestamp;
+    keystroke_type: KeystrokeType;
+    created_at: UnixTimestamp;
 }

--- a/src/octopeer-github/main/Database/EventObject/KeystrokeEvent.ts
+++ b/src/octopeer-github/main/Database/EventObject/KeystrokeEvent.ts
@@ -2,6 +2,10 @@
  * Created by Maarten on 26-05-2016.
  */
 
+/**
+ * A set of constants used for defining keystroke types.
+ */
+// tslint:disable-next-line:no-unused-variable
 const KeystrokeType = {
     KEY_DOWN: 1,
     KEY_UP: 2,

--- a/src/octopeer-github/main/Database/EventObject/MouseClickEvent.ts
+++ b/src/octopeer-github/main/Database/EventObject/MouseClickEvent.ts
@@ -4,7 +4,7 @@
 
 /**
  * A MouseClickEvent contains the data that should be posted to a Database.
- * @param timestamp     when the event was created.
+ * @param created_at     when the event was created.
  */
 interface MouseClickEvent {
     created_at: UnixTimestamp;

--- a/src/octopeer-github/main/Database/EventObject/MousePositionEvent.ts
+++ b/src/octopeer-github/main/Database/EventObject/MousePositionEvent.ts
@@ -8,7 +8,7 @@
  * @param position_y    specifies the y-position on the page (i.e. relative to the top-left corner of the document).
  * @param viewport_x    specifies the x-position on the viewport (i.e. relative to the top-left corner of the window).
  * @param viewport_y    specifies the y-position on the viewport (i.e. relative to the top-left corner of the window).
- * @param timestamp     when the event was created.
+ * @param created_at     when the event was created.
  */
 interface MousePositionEvent {
     position_x: number;

--- a/src/octopeer-github/main/Database/EventObject/MouseScrollEvent.ts
+++ b/src/octopeer-github/main/Database/EventObject/MouseScrollEvent.ts
@@ -6,7 +6,7 @@
  * A MouseScrollEvent contains the data that should be posted to a Database.
  * @param viewport_x    indicates the x-position of the current viewport.
  * @param viewport_y    indicates the y-position of the current viewport.
- * @param timestamp     when the event was created.
+ * @param created_at    when the event was created.
  */
 interface MouseScrollEvent {
     viewport_x: number;

--- a/src/octopeer-github/main/Database/EventObject/SemanticEvent.ts
+++ b/src/octopeer-github/main/Database/EventObject/SemanticEvent.ts
@@ -15,6 +15,7 @@ type LineNumber = number;
  * @param duration      the duration of the event.
  * @param filename      the name of the file in inline tracking.
  * @param lineNumber    the linenumber in the file in inline tracking.
+ * @param created_at    when the event was created.
  */
 interface SemanticEvent {
     elementID: ElementID;

--- a/src/octopeer-github/test/content/EventTracker/KeystrokeTrackerTest.ts
+++ b/src/octopeer-github/test/content/EventTracker/KeystrokeTrackerTest.ts
@@ -12,22 +12,24 @@ describe("A KeystrokeTracker", function() {
         tracker = new KeystrokeTracker(db);
     });
 
-    it("should track keypress events", function() {
-        const dbSpy = spyOn(db, "post");
-        tracker.addDOMEvent();
+    for (let eventtype of ["keydown", "keyup"]) {
+        it(`should track ${eventtype} events`, function () {
+            const dbSpy = spyOn(db, "post");
+            tracker.addDOMEvent();
 
-        $("body").trigger($.Event("keypress", {which: " "}));
+            $("body").trigger($.Event(eventtype, {key: "p"}));
 
-        expect(dbSpy).toHaveBeenCalledTimes(1);
-    });
+            expect(dbSpy).toHaveBeenCalledTimes(1);
+        });
 
-    it("should no longer track keypress events when removed from DOM", function() {
-        const dbSpy = spyOn(db, "post");
-        tracker.addDOMEvent();
-        tracker.removeDOMEvent();
+        it(`should no longer track ${eventtype} events when removed from DOM`, function () {
+            const dbSpy = spyOn(db, "post");
+            tracker.addDOMEvent();
+            tracker.removeDOMEvent();
 
-        $("body").trigger($.Event("keypress", {which: " "}));
+            $("body").trigger($.Event(eventtype, {key: "p"}));
 
-        expect(dbSpy).not.toHaveBeenCalled();
-    });
+            expect(dbSpy).not.toHaveBeenCalled();
+        });
+    }
 });

--- a/src/octopeer-github/test/main/Database/EventFactoryTest.ts
+++ b/src/octopeer-github/test/main/Database/EventFactoryTest.ts
@@ -23,6 +23,11 @@ describe("An EventFactory", function() {
             });
     });
 
+    it("should properly create KeystrokeEvents without Timestamp", function() {
+        expect(EventFactory.keystroke("q", KeystrokeType.KEY_DOWN).data)
+            .toEqual(jasmine.objectContaining({keystroke: "q", keystroke_type: KeystrokeType.KEY_DOWN}));
+    });
+
     it("should properly create KeystrokeEvents with keyDown", function() {
         expect(EventFactory.keyDown("q", defaultTime))
             .toEqual({

--- a/src/octopeer-github/test/main/Database/EventFactoryTest.ts
+++ b/src/octopeer-github/test/main/Database/EventFactoryTest.ts
@@ -23,10 +23,18 @@ describe("An EventFactory", function() {
             });
     });
 
-    it("should properly create KeystrokeEvents", function() {
-        expect(EventFactory.keystroke("q", defaultTime, defaultTime + 100))
+    it("should properly create KeystrokeEvents with keyDown", function() {
+        expect(EventFactory.keyDown("q", defaultTime))
             .toEqual({
-                data: {key_down_at: defaultTime, key_up_at: defaultTime + 100, keystroke: "q"},
+                data: {created_at: defaultTime, keystroke: "q", keystroke_type: KeystrokeType.KEY_DOWN},
+                type: "KeystrokeEvent",
+            });
+    });
+
+    it("should properly create KeystrokeEvents with keyUp", function() {
+        expect(EventFactory.keyUp("q", defaultTime))
+            .toEqual({
+                data: {created_at: defaultTime, keystroke: "q", keystroke_type: KeystrokeType.KEY_UP},
                 type: "KeystrokeEvent",
             });
     });


### PR DESCRIPTION
Will close #137 

`keydown` and `keyup` events are now properly logged to the Database of Aaron, in the new way.
Changes:
- `KeystrokeEvent` no longer has `key_down_at` and `key_up_at`, but just `created_at`.
- `KeystrokeEvent` now has a field `keystroke_type` for which two constants are defined in the type `KeystrokeType`: `KEY_DOWN` and `KEY_UP` (which represent 1 and 2 respectively).
- `EventFactory` now has two functions `keyUp` and `keyDown` which create the two types of events without having to look up the constant and can be used for convenience. 
- Event that is hooked to DOM is now `keydown`/`keyup` instead of `keypress`, meaning also special keys will be logged to the database (things like `Control`, `Backspace`, etc. Space is represented as ` `, as usual).
- While I was busy, I updated some JSDoc that was outdated.

Have fun reviewing :D 