### PR TITLE
152   remove status.setter

### DIFF
--- a/src/octopeer-github/main/Status.ts
+++ b/src/octopeer-github/main/Status.ts
@@ -89,11 +89,11 @@ const Status = new (class Status {
      * @param status
      */
     public set(status: StatusCode) {
-        this.status = status;
-
         if (!Options.get(Options.LOGGING)) {
             status = StatusCode.OFF;
         }
+
+        this.status = status;
 
         chrome.runtime.sendMessage({
             line: Status.MESSAGE[status],

--- a/src/octopeer-github/main/Status.ts
+++ b/src/octopeer-github/main/Status.ts
@@ -90,27 +90,11 @@ const Status = new (class Status {
      */
     public set(status: StatusCode) {
         this.status = status;
-        if (Options.get(Options.LOGGING)) {
-            this.setter(status);
-        } else {
-            this.setter(StatusCode.OFF);
+
+        if (!Options.get(Options.LOGGING)) {
+            status = StatusCode.OFF;
         }
-    }
 
-    /**
-     * Accepts a status and returns true if this is the current status.
-     * @param s the status to check against
-     * @returns {boolean} whether the current status equals s
-     */
-    public isStatus(s: StatusCode): Boolean {
-        return s === this.status;
-    }
-
-    /**
-     * Helper method for set() in order to prevent duplicate code.
-     * @param status
-     */
-    private setter(status: StatusCode) {
         chrome.runtime.sendMessage({
             line: Status.MESSAGE[status],
             path: this.getIcon(status),
@@ -122,5 +106,14 @@ const Status = new (class Status {
         chrome.browserAction.setIcon({
             path: `resources/` + this.getIcon(status, 19),
         });
+    }
+
+    /**
+     * Accepts a status and returns true if this is the current status.
+     * @param s the status to check against
+     * @returns {boolean} whether the current status equals s
+     */
+    public isStatus(s: StatusCode): Boolean {
+        return s === this.status;
     }
 })();

--- a/src/octopeer-github/test/main/StatusTest.ts
+++ b/src/octopeer-github/test/main/StatusTest.ts
@@ -67,16 +67,20 @@ describe("The Status, when the state is changed", function() {
 describe("The Status, when set", function() {
     it("by the set function, should set its internal variable to off, if Octopeer is not allowed to log", function () {
         let spyOptions = spyOn(Options, "get").and.returnValue(false);
-        Status.set(StatusCode.ERROR);
+        let statusCode = StatusCode.ERROR;
+
+        Status.set(statusCode);
         expect(spyOptions).toHaveBeenCalled();
-        expect(Status.isStatus(StatusCode.OFF));
+        expect(Status.isStatus(statusCode));
     });
 
     it("by the set function, should set its internal variable the requested variable, if Octopeer is allowed to log", function () {
         let spyOptions = spyOn(Options, "get").and.returnValue(true);
-        Status.set(StatusCode.ERROR);
+        let statusCode = StatusCode.ERROR;
+
+        Status.set(statusCode);
         expect(spyOptions).toHaveBeenCalled();
-        expect(Status.isStatus(StatusCode.ERROR));
+        expect(Status.isStatus(statusCode));
     });
 
     it("by the helper method 'setter' should update the new status by setting new properties with functions of chrome.", function () {

--- a/src/octopeer-github/test/main/StatusTest.ts
+++ b/src/octopeer-github/test/main/StatusTest.ts
@@ -68,10 +68,11 @@ describe("The Status, when set", function() {
     it("by the set function, should set its internal variable to off, if Octopeer is not allowed to log", function () {
         let spyOptions = spyOn(Options, "get").and.returnValue(false);
         let statusCode = StatusCode.ERROR;
+        let statusCodeExpected = StatusCode.OFF;
 
         Status.set(statusCode);
         expect(spyOptions).toHaveBeenCalled();
-        expect(Status.isStatus(statusCode));
+        expect(Status.isStatus(statusCodeExpected));
     });
 
     it("by the set function, should set its internal variable the requested variable, if Octopeer is allowed to log", function () {

--- a/src/octopeer-github/test/main/StatusTest.ts
+++ b/src/octopeer-github/test/main/StatusTest.ts
@@ -65,22 +65,18 @@ describe("The Status, when the state is changed", function() {
 });
 
 describe("The Status, when set", function() {
-
-    it("by the set function, should call helper method setter with the given status, if Octopeer is allowed to log", function () {
-        let spyOptions = spyOn(Options, "get").and.returnValue(true);
-        let spySetter = spyOn(Status, "setter");
-        let statusCode = StatusCode.ERROR;
-        Status.set(statusCode);
-        expect(spyOptions).toHaveBeenCalled();
-        expect(spySetter).toHaveBeenCalledWith(statusCode);
-    });
-
-    it("by the set function, should call helper method setter with the StatusCode off, if Octopeer is not allowed to log", function () {
+    it("by the set function, should set its internal variable to off, if Octopeer is not allowed to log", function () {
         let spyOptions = spyOn(Options, "get").and.returnValue(false);
-        let spySetter = spyOn(Status, "setter");
         Status.set(StatusCode.ERROR);
         expect(spyOptions).toHaveBeenCalled();
-        expect(spySetter).toHaveBeenCalledWith(StatusCode.OFF);
+        expect(Status.isStatus(StatusCode.OFF));
+    });
+
+    it("by the set function, should set its internal variable the requested variable, if Octopeer is allowed to log", function () {
+        let spyOptions = spyOn(Options, "get").and.returnValue(true);
+        Status.set(StatusCode.ERROR);
+        expect(spyOptions).toHaveBeenCalled();
+        expect(Status.isStatus(StatusCode.ERROR));
     });
 
     it("by the helper method 'setter' should update the new status by setting new properties with functions of chrome.", function () {


### PR DESCRIPTION
Will close #152.

After the feedback from Bastiaan about the undescriptive naming of Settings.setter the plan was to adjust the name when examining the code I came to the conclusion that this can easily be fixed with a minor refactor. the test has been updated accordingly.