### PR TITLE
102 set error status

### DIFF
--- a/src/octopeer-github/content/ContentController.ts
+++ b/src/octopeer-github/content/ContentController.ts
@@ -1,5 +1,6 @@
 /// <reference path="../main/Options/DoNotWatchOptions.ts"/>
 /// <reference path="../main/Database/ConsoleLogDatabaseAdapter.ts"/>
+/// <reference path="../main/Status.ts"/>
 /// <reference path="../main/URLHandler.ts"/>
 /// <reference path="ElementEventBinding/ElementEventBinding.ts"/>
 
@@ -77,19 +78,19 @@ class ContentController {
     private processMessageFromBackgroundPage() {
         return (request: any, sender: any, sendResponse: Function) => {
             if (request.hookToDom === undefined) {
-                sendResponse(`did nothing (${location.href})`);
+                sendResponse({message: `did nothing (${location.href})`, status: StatusCode.ERROR});
                 return;
             }
             try {
                 if (request.hookToDom) {
                     this.hookToDOM(this.messageSendDatabaseAdapter);
-                    sendResponse(`hooked to DOM (${location.href})`);
+                    sendResponse({message: `hooked to DOM (${location.href})`, status: StatusCode.RUNNING});
                 } else {
                     this.unhookFromDOM(this.messageSendDatabaseAdapter);
-                    sendResponse(`unhooked from DOM (${location.href})`);
+                    sendResponse({message: `unhooked from DOM (${location.href})`, status: StatusCode.STANDBY});
                 }
             } catch (e) {
-                sendResponse(`has errored (${location.href})\n[ERR] ${e}`);
+                sendResponse({message: `has errored (${location.href})\n[ERR] ${e}`, status: StatusCode.ERROR});
                 console.error(e);
                 return;
             }

--- a/src/octopeer-github/content/ContentController.ts
+++ b/src/octopeer-github/content/ContentController.ts
@@ -1,6 +1,5 @@
 /// <reference path="../main/Options/DoNotWatchOptions.ts"/>
 /// <reference path="../main/Database/ConsoleLogDatabaseAdapter.ts"/>
-/// <reference path="../main/Status.ts"/>
 /// <reference path="../main/URLHandler.ts"/>
 /// <reference path="ElementEventBinding/ElementEventBinding.ts"/>
 
@@ -78,19 +77,19 @@ class ContentController {
     private processMessageFromBackgroundPage() {
         return (request: any, sender: any, sendResponse: Function) => {
             if (request.hookToDom === undefined) {
-                sendResponse({message: `did nothing (${location.href})`, status: StatusCode.ERROR});
+                sendResponse({message: `did nothing (${location.href})`, error: true});
                 return;
             }
             try {
                 if (request.hookToDom) {
                     this.hookToDOM(this.messageSendDatabaseAdapter);
-                    sendResponse({message: `hooked to DOM (${location.href})`, status: StatusCode.RUNNING});
+                    sendResponse({message: `hooked to DOM (${location.href})`});
                 } else {
                     this.unhookFromDOM(this.messageSendDatabaseAdapter);
-                    sendResponse({message: `unhooked from DOM (${location.href})`, status: StatusCode.STANDBY});
+                    sendResponse({message: `unhooked from DOM (${location.href})`});
                 }
             } catch (e) {
-                sendResponse({message: `has errored (${location.href})\n[ERR] ${e}`, status: StatusCode.ERROR});
+                sendResponse({message: `has errored (${location.href})\n[ERR] ${e}`, error: true});
                 console.error(e);
                 return;
             }

--- a/src/octopeer-github/content/ContentController.ts
+++ b/src/octopeer-github/content/ContentController.ts
@@ -77,7 +77,7 @@ class ContentController {
     private processMessageFromBackgroundPage() {
         return (request: any, sender: any, sendResponse: Function) => {
             if (request.hookToDom === undefined) {
-                sendResponse({message: `did nothing (${location.href})`, error: true});
+                sendResponse({error: true, message: `did nothing (${location.href})`});
                 return;
             }
             try {
@@ -89,7 +89,7 @@ class ContentController {
                     sendResponse({message: `unhooked from DOM (${location.href})`});
                 }
             } catch (e) {
-                sendResponse({message: `has errored (${location.href})\n[ERR] ${e}`, error: true});
+                sendResponse({error: true, message: `has errored (${location.href})\n[ERR] ${e}`});
                 console.error(e);
                 return;
             }

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -165,6 +165,7 @@ class MainController implements OptionsObserver {
         const failure = function() {
             Logger.warn("Log to database of following object failed:");
             Logger.warn(message);
+            Status.error();
         };
         this.getDatabase(this.user, prUrl).post(message, success, failure);
     }

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -217,7 +217,9 @@ class MainController implements OptionsObserver {
             }
             let str = result.message || `will be refreshed because content script is not loaded (${tab.url})`;
             Logger.debug(`[Tab] ${str}`);
-            Status.set(result.status);
+            if (result.error) {
+                Status.set(StatusCode.ERROR);
+            }
         });
     }
 

--- a/src/octopeer-github/main/MainController.ts
+++ b/src/octopeer-github/main/MainController.ts
@@ -207,15 +207,17 @@ class MainController implements OptionsObserver {
      * @param tab The tab to send this message to.
      * @param hookToDom true if the tab should hook to DOM, false if the tab should unhook from DOM.
      */
-    private sendMessageToContentScript(tab: Tab, hookToDom: boolean) {
+    private sendMessageToContentScript(tab: Tab, hookToDom = false) {
         chrome.tabs.sendMessage(tab.id, {
             hookToDom: hookToDom,
         }, function (result) {
             if (!result) {
                 chrome.tabs.reload(tab.id);
+                result = {};
             }
-            let str = result || `will be refreshed because content script is not loaded (${tab.url})`;
+            let str = result.message || `will be refreshed because content script is not loaded (${tab.url})`;
             Logger.debug(`[Tab] ${str}`);
+            Status.set(result.status);
         });
     }
 


### PR DESCRIPTION
Will close #102 
~~Please merge #188 and #189 first, as this PR depends on those PRs.~~

I made sure the `ERROR` status is set on two occasions:

- The DatabaseAdapter calls the failure callback
- The ContentController errors while hooking to DOM

If there are other occasions that should have an `ERROR` status, please tell me :)

Have fun breaking our extension :D 