### PR TITLE
Format space keystroke

### DIFF
--- a/src/octopeer-github/main/Database/RESTApiDatabaseAdapter.ts
+++ b/src/octopeer-github/main/Database/RESTApiDatabaseAdapter.ts
@@ -102,6 +102,12 @@ class RESTApiDatabaseAdapter implements DatabaseAdaptable {
                 "element_type": data.elementID.getElementID(),
                 "created_at": data.created_at,
             };
+        } if (eventData.type === "KeystrokeEvent") {
+            const data = <KeystrokeEvent>eventData.data;
+            if (data.keystroke === " ") {
+                data.keystroke = "Space";
+            }
+            return data;
         } else {
             return this.processRounding(eventData.data);
         }

--- a/src/octopeer-github/main/Database/RESTApiDatabaseAdapter.ts
+++ b/src/octopeer-github/main/Database/RESTApiDatabaseAdapter.ts
@@ -95,21 +95,22 @@ class RESTApiDatabaseAdapter implements DatabaseAdaptable {
      * @returns {any} the JSON-compatible formatted data that is going to be posted to the database.
      */
     private processEventObject(eventData: EventObject): any {
-        if (eventData.type === "SemanticEvent") {
-            const data = <SemanticEvent>eventData.data;
-            return {
-                "event_type": data.eventID.getEventID(),
-                "element_type": data.elementID.getElementID(),
-                "created_at": data.created_at,
-            };
-        } if (eventData.type === "KeystrokeEvent") {
-            const data = <KeystrokeEvent>eventData.data;
-            if (data.keystroke === " ") {
-                data.keystroke = "Space";
-            }
-            return data;
-        } else {
-            return this.processRounding(eventData.data);
+        switch (eventData.type) {
+            case "SemanticEvent":
+                const semanticData = <SemanticEvent>eventData.data;
+                return {
+                    "event_type": semanticData.eventID.getEventID(),
+                    "element_type": semanticData.elementID.getElementID(),
+                    "created_at": semanticData.created_at,
+                };
+            case "KeystrokeEvent":
+                const keystrokeData = <KeystrokeEvent>eventData.data;
+                if (keystrokeData.keystroke === " ") {
+                    keystrokeData.keystroke = "Space";
+                }
+                return keystrokeData;
+            default:
+                return this.processRounding(eventData.data);
         }
     }
 

--- a/src/octopeer-github/test/main/Database/RESTApiDatabaseAdapterTest.ts
+++ b/src/octopeer-github/test/main/Database/RESTApiDatabaseAdapterTest.ts
@@ -168,4 +168,13 @@ describe("A RESTApiDatabaseAdapter", function() {
             viewport_y: 13,
         }));
     });
+
+    it("has to rewrite space keystrokes to `Space`", function() {
+        adapter.post(EventFactory.keyDown(" "), EMPTY_CALLBACK, EMPTY_CALLBACK);
+        let expected = (<any>jasmine.Ajax.requests.mostRecent()).params;
+
+        expect(JSON.parse(expected)).toEqual(jasmine.objectContaining({
+            keystroke: "Space",
+        }));
+    });
 });


### PR DESCRIPTION
In the content controller, `" "` is now rewritten to `"Space"` to avoid 400 errors. I asked @aaronang about this and he approves this change.

Have fun reviewing, it's not much :)